### PR TITLE
Link against libstdc++

### DIFF
--- a/makeEspArduino.mk
+++ b/makeEspArduino.mk
@@ -85,7 +85,7 @@ C_FLAGS ?= -c -Os -g -Wpointer-arith -Wno-implicit-function-declaration -Wl,-EL 
 CPP_FLAGS ?= -c -Os -g -mlongcalls -mtext-section-literals -fno-exceptions -fno-rtti -falign-functions=4 -std=c++11 -MMD -ffunction-sections -fdata-sections
 S_FLAGS ?= -c -g -x assembler-with-cpp -MMD
 LD_FLAGS ?= -g -w -Os -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static -L$(SDK_ROOT)/lib -L$(SDK_ROOT)/ld -T$(FLASH_LAYOUT) -Wl,--gc-sections -Wl,-wrap,system_restart_local -Wl,-wrap,register_chipv6_phy
-LD_STD_LIBS ?= -lm -lgcc -lhal -lphy -lnet80211 -llwip -lwpa -lmain -lpp -lsmartconfig -lwps -lcrypto -laxtls
+LD_STD_LIBS ?= -lm -lgcc -lhal -lphy -lnet80211 -llwip -lwpa -lmain -lpp -lsmartconfig -lwps -lcrypto -laxtls -lstdc++
 
 # Core source files
 CORE_DIR = $(ESP_ROOT)/cores/esp8266


### PR DESCRIPTION
Since https://github.com/esp8266/Arduino/commit/de166c9, esp8266/Arduino core has to be linked against -lstdc++.
Problem is, for older versions this will not work. Not sure how to handle this best in the context of a makefile, just putting this on your radar.