### PR TITLE
Autoinclude libraries used in any of the users source files

### DIFF
--- a/makeEspArduino.mk
+++ b/makeEspArduino.mk
@@ -98,7 +98,7 @@ ifeq ($(wildcard $(ESP_ROOT)/cores/$(CHIP)),)
   $(error $(ESP_ROOT) is not a vaild directory for $(CHIP))
 endif
 
-ESPTOOL_PY ?= $(shell which esptool.py)
+ESPTOOL_PY ?= "$(shell which esptool.py)"
 ifneq ($(ESPTOOL_PY),)
   # esptool.py exists, use it for esp8266 flash operations
   ESPTOOL_PY += --baud=$(UPLOAD_SPEED) --port $(UPLOAD_PORT)


### PR DESCRIPTION
**TL;DR**: This pull request changes the behavior of the makefile to not only look for libraries used in the projects `.ino` file. Instead all related source files within the project directory are used. This was successfully tested on linux as well as cygwin. 

**The Problem**
You want to compile an project consisting of the following files: `Test.ino`, `SettingsProvider.c` and `SettingsProvider.h`

The file `Test.ino` is your sketch file. It includes `SettingsProvider.h`. The file `SettingsProvider.c` uses the esp8266 EEPROM-library (included via `include <EEPROM.h>`).

Trying to compile this example fails on grounds of the missing EEPROM-library which gets not detected automatically since it is not explicitly included in the `Test.ino` file.

**The Solution**
Search for used libraries by not only looking at the includes of the sketch-file but instead all project related, user created, files.

Further the library detection on cygwin suffered a problem with wrong path separators. It was fixed by converting the windows-style path separators to unix-style path separators. Now they get properly parsed by the inline perl on line 157.
