### PR TITLE
Make numer of build threads configurable

### DIFF
--- a/makeEspArduino.mk
+++ b/makeEspArduino.mk
@@ -374,6 +374,7 @@ help:
 	echo "                         Default: $(LWIP_VARIANT) ($(LWIP_INFO))"
 	echo "  VERBOSE              Set to 1 to get full printout of the build"
 	echo "  SINGLE_THREAD        Use only one build thread"
+	echo "  NUM_OF_THREADS       Number of build threads. Default: $(NUM_OF_THREADS)"
 	echo
 
 $(BUILD_DIR):
@@ -393,9 +394,11 @@ endif
 
 .DEFAULT_GOAL = all
 
+NUM_OF_THREADS ?= $(shell cat /proc/cpuinfo | grep -c processor)
+
 ifndef SINGLE_THREAD
   # Use multithreaded builds by default
-  MAKEFLAGS += -j
+  MAKEFLAGS += -j $(NUM_OF_THREADS)
 endif
 
 ifndef VERBOSE


### PR DESCRIPTION
When I was trying to compile project on Raspberry, it by default used -j flag, but without any parameter. It allowed to fork quite a large number of threads and as the result, out of memory error. This change will limit number of threads up to the number of logical cores.