### PR TITLE
Prefer `/src` for libraries, and recursively search for included headers inside of libraries.

### DIFF
--- a/makeEspArduino.mk
+++ b/makeEspArduino.mk
@@ -351,8 +351,16 @@ upload_fs flash_fs: $(FS_IMAGE)
 ota_fs: $(FS_IMAGE)
 	$(OTA_TOOL) $(OTA_ARGS) --spiffs --file="$(FS_IMAGE)"
 
+MONITOR_COM := python -m serial.tools.miniterm --rts=0 --dtr=0 $(UPLOAD_PORT) $(UPLOAD_SPEED)
+
 run: flash
-	python -m serial.tools.miniterm --rts=0 --dtr=0 $(UPLOAD_PORT) 115200
+	$(MONITOR_COM)
+
+monitor:
+	$(MONITOR_COM)
+
+reset:
+	$(ESPTOOL_PATTERN) --no-stub run
 
 FLASH_FILE ?= $(BUILD_DIR)/esp_flash.bin
 dump_flash:

--- a/makeEspArduino.mk
+++ b/makeEspArduino.mk
@@ -300,7 +300,7 @@ $(BUILD_DIR)/%.S.o: %.S
 
 $(CORE_LIB): $(CORE_OBJ)
 	echo  Creating core archive
-	rm -f $@
+	$(RM) $@
 	$(CORE_LIB_COM) $^
 
 ifdef USER_RULES

--- a/makeEspArduino.mk
+++ b/makeEspArduino.mk
@@ -28,6 +28,7 @@ BOARD ?= $(if $(filter $(CHIP), esp32),esp32,generic)
 # Serial flashing parameters
 UPLOAD_PORT ?= $(shell ls -1tr /dev/tty*USB* 2>/dev/null | tail -1)
 UPLOAD_PORT := $(if $(UPLOAD_PORT),$(UPLOAD_PORT),/dev/ttyS0)
+UPLOAD_VERB ?= -v
 
 # OTA parameters
 ESP_ADDR ?= ESP_123456
@@ -550,6 +551,7 @@ def_var('build.flash_freq', 'FLASH_SPEED');
 def_var('upload.resetmethod', 'UPLOAD_RESET');
 def_var('upload.speed', 'UPLOAD_SPEED');
 def_var('compiler.warning_flags', 'COMP_WARNINGS');
+$$v{'upload.verbose'} = '$$(UPLOAD_VERB)';
 $$v{'serial.port'} = '$$(UPLOAD_PORT)';
 $$v{'recipe.objcopy.hex.pattern'} =~ s/[^"]+\/bootloaders\/eboot\/eboot.elf/\$$(BOOT_LOADER)/;
 $$v{'recipe.objcopy.hex.1.pattern'} =~ s/[^"]+\/bootloaders\/eboot\/eboot.elf/\$$(BOOT_LOADER)/;


### PR DESCRIPTION
Fixes https://github.com/plerup/makeEspArduino/issues/109.