### PR TITLE
Allow user create config automaticaly used in all projects

### DIFF
--- a/makeEspArduino.mk
+++ b/makeEspArduino.mk
@@ -14,6 +14,21 @@
 #====================================================================================
 # Project specific values
 #====================================================================================
+# Include user config
+ifeq ($(MAKEESPARDUINO_CONFIGS_ROOT),)
+  ifeq ($(OS), Windows_NT)
+    MAKEESPARDUINO_CONFIGS_ROOT = $(shell cygpath -m $(LOCALAPPDATA)/makeEspArduino)
+  else ifeq ($(OS), Darwin)
+    MAKEESPARDUINO_CONFIGS_ROOT = $(HOME)/Library/makeEspArduino
+  else
+    ifneq ($(XDG_CONFIG_HOME),)
+      MAKEESPARDUINO_CONFIGS_ROOT = $(XDG_CONFIG_HOME)/makeEspArduino
+    else
+      MAKEESPARDUINO_CONFIGS_ROOT = $(HOME)/.config/makeEspArduino
+    endif
+  endif
+endif
+-include $(MAKEESPARDUINO_CONFIGS_ROOT)/config.mk
 
 # Include possible project makefile. This can be used to override the defaults below
 -include $(firstword $(PROJ_CONF) $(dir $(SKETCH))config.mk)


### PR DESCRIPTION
my common config as example is:

```
#
# ~/.config/makeEspArduino/config.mk config file
#
BUILD_ROOT = $(shell pwd)/.build
#BUILD_DIR  = $(BUILD_ROOT)/$(DEVICE_NAME)_$(DEVICE_MOD)

BUILD_THREADS = 16

VERBOSE = 1
USE_CCACHE = 1

UPLOAD_PORT = /dev/ttyUSB0
#UPLOAD_SPEED = 115200
#UPLOAD_SPEED = 230400
UPLOAD_SPEED = 460800
#UPLOAD_SPEED = 500000
#UPLOAD_SPEED = 576000
#UPLOAD_SPEED = 921600

HTTP_ADDR ?= $(OTA_ADDR)

#STASSID = your-ssid
#STAPSK  = your-password
#BUILD_EXTRA_FLAGS += -DSTASSID=\"$(STASSID)\" -DSTAPSK=\"$(STAPSK)\"

```
