### PR TITLE
Adjust commandline for installing espmake32

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you want to minimize your typing henceforth then there is a rule in that make
 
     make -f makeEspArduino.mk ESP_ROOT=~/esp8266 install
 
-    make -f makeEspArduino.mk ESP_ROOT=~/esp32 CHIP=ESP32 install
+    make -f makeEspArduino.mk ESP_ROOT=~/esp32 CHIP=esp32 install
 
 Sudo access will be required for this operation.
 


### PR DESCRIPTION
Hello @plerup,

First of all a warm thank you for creating and sharing such a useful tool!

By looking at the `README.md` I believe I found I small typo, more specifically the value for CHIP environment variable in the instructions for creating the `espmake32` alias was incorrectly spelled in the documented commandline.

Thank you very much for your attention,
Gianpaolo