### PR TITLE
Ensure a lib path exists before assuming it is a file.

### DIFF
--- a/tools/find_src.pl
+++ b/tools/find_src.pl
@@ -76,7 +76,7 @@ if ($libs[0] =~ /(.+)\/examples\//) {
 # First find possible explicit library source or achive files from the the specified list
 for (my $i = 0; $i < @libs; $i++ ) {
   my $path = $libs[$i];
-  if (!-d $path) {
+  if (-e $path && ! -d $path) {
     # File specification
     $libs[$i] = dirname($path);
     # Mark as known source directory, except for sketch directory


### PR DESCRIPTION
Without this, a path like "/libraries" (that probably doesn't exist on
most Linux installs), will get converted into "/", and cause 'find' to
scan the entire filesystem. This is somewhat unfortunate when there is
a large, slow filesystem mounted, such as a NAS.

This isn't really a complete fix, since symlinks will still be treated
somewhat surprisingly, but it's definitely nice to not scan an extra
15T of storage.