### PR TITLE
Swap to curly braces for pkg_subst to work in OpenBSD.

### DIFF
--- a/os/OpenBSD.mk
+++ b/os/OpenBSD.mk
@@ -13,11 +13,11 @@
 #====================================================================================
 
 CONFIG_ROOT ?= $(HOME)/Library
-ARDUINO_ROOT ?= $(LOCALBASE)/share/arduino
+ARDUINO_ROOT ?= ${LOCALBASE}/share/arduino
 ARDUINO_HW_ESP_ROOT = $(ARDUINO_ROOT)/hardware/espressif/$(CHIP)
 UPLOAD_PORT_MATCH ?= /dev/tty*U*
 CMD_LINE = $(shell ps $$PPID -o command | tail -1)
 OS_NAME = openbsd
 BUILD_THREADS ?= $(shell sysctl -n hw.ncpuonline)
-ARDUINO_LIBS = $(LOCALBASE)/share/arduino/libraries
-CUSTOM_LIBS += $(LOCALBASE)/avr/include
+ARDUINO_LIBS = ${LOCALBASE}/share/arduino/libraries
+CUSTOM_LIBS += ${LOCALBASE}/avr/include


### PR DESCRIPTION
Hello, $(LOCALBASE) is not picked up during gmake in OpenBSD, unless the env is set up with it. Previously, I was patching for curly braces and using the ports SUBST_CMD to replace for users. Instead of having users set their environment for each build and avoiding a patch, this diff will allow me to fix-up the port for users. SUBST_CMD (pkg_subst(1)) requires the curlies.

This and another quick release would be awesome!

Thanks.