### PR TITLE
Fix SKETCH_CPP with the appropriate main name

### DIFF
--- a/makeEspArduino.mk
+++ b/makeEspArduino.mk
@@ -190,7 +190,7 @@ $(SRC_LIST): $(MAKEFILE_LIST) $(FIND_SRC_CMD) | $(BUILD_DIR)
 -include $(SRC_LIST)
 
 # Use sketch copy with correct C++ extension
-SKETCH_CPP = $(BUILD_DIR)/$(notdir $(SKETCH)).cpp
+SKETCH_CPP = $(BUILD_DIR)/$(notdir $(MAIN_NAME)).cpp
 USER_SRC := $(subst $(SKETCH),$(SKETCH_CPP),$(USER_SRC))
 
 USER_OBJ := $(patsubst %,$(BUILD_DIR)/%$(OBJ_EXT),$(notdir $(USER_SRC)))


### PR DESCRIPTION
This small replacement fixes the main sketch names that resulted in a duplicate .cpp extension
(Tested on OpenBSD)