### PR TITLE
Set VSCode C & C++ standard to gnu99 & gnu++11

### DIFF
--- a/tools/vscode.pl
+++ b/tools/vscode.pl
@@ -110,8 +110,8 @@ my $this_prop_json = <<"EOT";
   "includePath": [$inc],
   "defines": [$def],
   "compilerPath": "$comp_path",
-  "cStandard": "c11",
-  "cppStandard": "c++11"
+  "cStandard": "gnu99",
+  "cppStandard": "gnu++11"
 }
 EOT
 make_portable($this_prop_json, $workspace_dir);


### PR DESCRIPTION
This sets the C and C++ standards that the VSCode extension uses to the [C and C++ standards used by arduino-esp32](https://github.com/espressif/arduino-esp32/blob/6a7bcabd6b7a33f074f93ed60e5cc4378d350b81/platform.txt#L28-L29).

This helps remove IDE nagging when encountering gcc specific `#define`s, as well as just generally helping to set the correct standards right from the get go so it wouldn't have to be changed manually.