### PR TITLE
fix spiffs path for openbsd

### DIFF
--- a/makeEspArduino.mk
+++ b/makeEspArduino.mk
@@ -94,12 +94,12 @@ ifndef ESP_ROOT
   ESP_ARDUINO_VERSION := $(notdir $(ESP_ROOT))
   # Find used version of compiler and tools
   COMP_PATH := $(lastword $(wildcard $(ARDUINO_ESP_ROOT)/tools/xtensa-*/*))
-  MK_FS_PATH := $(lastword $(wildcard $(ARDUINO_ESP_ROOT)/tools/$(MK_FS_MATCH)/*/$(MK_FS_MATCH)))
+  MK_FS_PATH ?= $(lastword $(wildcard $(ARDUINO_ESP_ROOT)/tools/$(MK_FS_MATCH)/*/$(MK_FS_MATCH)))
   PYTHON3_PATH := $(lastword $(wildcard $(ARDUINO_ESP_ROOT)/tools/python3/*))
 else
   # Location defined, assume that it is a git clone
   ESP_ARDUINO_VERSION = $(call git_description,$(ESP_ROOT))
-  MK_FS_PATH := $(lastword $(wildcard $(ESP_ROOT)/tools/$(MK_FS_MATCH)/$(MK_FS_MATCH)))
+  MK_FS_PATH ?= $(lastword $(wildcard $(ESP_ROOT)/tools/$(MK_FS_MATCH)/$(MK_FS_MATCH)))
   PYTHON3_PATH := $(wildcard $(ESP_ROOT)/tools/python3)
 endif
 ESP_ROOT := $(abspath $(ESP_ROOT))

--- a/os/OpenBSD.mk
+++ b/os/OpenBSD.mk
@@ -21,3 +21,4 @@ OS_NAME = openbsd
 BUILD_THREADS ?= $(shell sysctl -n hw.ncpuonline)
 ARDUINO_LIBS = $(LOCALBASE)/share/arduino/libraries
 CUSTOM_LIBS += $(LOCALBASE)/avr/include
+MK_FS_PATH = $(LOCALBASE)/bin/mkspiffs


### PR DESCRIPTION
Hello, mkspiffs is installed outside of the toolchain on openbsd. Here is one possible fix for the new path check that was added. There is no rush here, as I'm not pushing this to our ports tree yet. I have another problem in the new arduino-esp32-2.0.6 to figure out first. Thanks.